### PR TITLE
Use trio.lowlevel instead of trio.hazmat to avoid a deprecation warning

### DIFF
--- a/src/trio_util/_async_bool.py
+++ b/src/trio_util/_async_bool.py
@@ -1,7 +1,11 @@
 from collections import defaultdict
 
 import trio
-from trio.hazmat import ParkingLot as WaitQueue
+
+try:
+    from trio.lowlevel import ParkingLot as WaitQueue
+except ImportError:
+    from trio.hazmat import ParkingLot as WaitQueue
 
 try:
     # work around numpy bool madness

--- a/src/trio_util/_async_value.py
+++ b/src/trio_util/_async_value.py
@@ -1,7 +1,11 @@
 from collections import defaultdict
 
 import trio
-from trio.hazmat import ParkingLot as WaitQueue
+
+try:
+    from trio.lowlevel import ParkingLot as WaitQueue
+except ImportError:
+    from trio.hazmat import ParkingLot as WaitQueue
 
 
 def _ANY_TRANSITION(value, old_value):

--- a/src/trio_util/_repeated_event.py
+++ b/src/trio_util/_repeated_event.py
@@ -1,4 +1,7 @@
-from trio.hazmat import ParkingLot as WaitQueue
+try:
+    from trio.lowlevel import ParkingLot as WaitQueue
+except ImportError:
+    from trio.hazmat import ParkingLot as WaitQueue
 
 
 class UnqueuedRepeatedEvent:


### PR DESCRIPTION
`trio.hazmat` is deprecated since Trio 0.15.0; this PR tries to import from `trio.lowlevel` first to avoid the deprecation warning, falling back to `trio.hazmat` for older versions of Trio.