### PR TITLE
Complete static typing

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE
+include src/trio_util/py.typed

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ An assortment of utilities for the Trio async/await framework, including:
     license='MIT',
     packages=[pkg_name],
     package_dir={'': 'src'},
+    package_data={'trio_util': ['py.typed']},
     install_requires=[
         'async_generator',
         'trio >= 0.11.0'

--- a/src/trio_util/__init__.py
+++ b/src/trio_util/__init__.py
@@ -12,7 +12,7 @@ from ._repeated_event import RepeatedEvent
 from ._task_stats import TaskStats
 from ._trio_async_generator import trio_async_generator
 
-def _metadata_fix():
+def _metadata_fix() -> None:
     # don't do this for Sphinx case because it breaks "bysource" member ordering
     import sys
     if 'sphinx' in sys.modules:  # pragma: no cover

--- a/src/trio_util/__init__.py
+++ b/src/trio_util/__init__.py
@@ -12,6 +12,22 @@ from ._repeated_event import RepeatedEvent
 from ._task_stats import TaskStats
 from ._trio_async_generator import trio_async_generator
 
+__all__ = [
+    '__version__',
+    'AsyncBool', 'AsyncValue',
+    'azip', 'azip_longest',
+    'wait_all', 'wait_any',
+    'move_on_when', 'run_and_cancelling',
+    'compose_values',
+    'defer_to_cancelled', 'multi_error_defer_to',
+    'iter_fail_after', 'iter_move_on_after',
+    'periodic',
+    'RepeatedEvent',
+    'TaskStats',
+    'trio_async_generator',
+]
+
+
 def _metadata_fix() -> None:
     # don't do this for Sphinx case because it breaks "bysource" member ordering
     import sys
@@ -21,5 +37,6 @@ def _metadata_fix() -> None:
     for name, value in globals().items():
         if not name.startswith('_'):
             value.__module__ = __name__
+
 
 _metadata_fix()

--- a/src/trio_util/_async_bool.py
+++ b/src/trio_util/_async_bool.py
@@ -1,7 +1,7 @@
 from ._async_value import AsyncValue
 
 
-class AsyncBool(AsyncValue):
+class AsyncBool(AsyncValue[bool]):
     """Boolean wrapper offering the ability to wait for a value or transition.
 
     Synopsis::
@@ -21,5 +21,5 @@ class AsyncBool(AsyncValue):
     same as AsyncValue.
     """
 
-    def __init__(self, value=False):
+    def __init__(self, value: bool = False) -> None:
         super().__init__(value)

--- a/src/trio_util/_async_itertools.py
+++ b/src/trio_util/_async_itertools.py
@@ -1,4 +1,4 @@
-from typing import Any, AsyncIterable, AsyncIterator, Tuple, TypeVar, Union, overload
+from typing import Any, AsyncIterable, AsyncIterator, List, Tuple, TypeVar, Union, overload
 
 import trio
 
@@ -16,7 +16,7 @@ async def _azip(aiterables: Tuple[AsyncIterable[Any], ...], fillvalue: object, s
     iters = [item.__aiter__() for item in aiterables]
     while True:
         stop_count = 0
-        items: list[object] = [fillvalue] * len(iters)
+        items: List[object] = [fillvalue] * len(iters)
 
         async def collect(i: int, iterator: AsyncIterator[object]) -> None:
             try:

--- a/src/trio_util/_async_itertools.py
+++ b/src/trio_util/_async_itertools.py
@@ -91,13 +91,30 @@ def azip_longest(
 @overload
 def azip_longest(
     __it1: AsyncIterable[T1], __it2: AsyncIterable[T2], __it3: AsyncIterable[T3],
-    __it4: AsyncIterable[T4]) -> AsyncIterator[Tuple[T1, T2, T3, T4]]: ...
+    __it4: AsyncIterable[T4],
+) -> AsyncIterator[Tuple[Union[T1, Any], Union[T2, Any], Union[T3, Any], Union[T4, Any]]]: ...
+@overload
+def azip_longest(
+    __it1: AsyncIterable[T1], __it2: AsyncIterable[T2], __it3: AsyncIterable[T3],
+    __it4: AsyncIterable[T4],
+    *, fillvalue: FillT,
+) -> AsyncIterator[Tuple[Union[T1, FillT], Union[T2, FillT], Union[T3, FillT], Union[T4, FillT]]]: ...
 # Five iterables
 @overload
 def azip_longest(
     __it1: AsyncIterable[T1], __it2: AsyncIterable[T2], __it3: AsyncIterable[T3],
     __it4: AsyncIterable[T4], __it5: AsyncIterable[T5],
-) -> AsyncIterator[Tuple[T1, T2, T3, T4, T5]]: ...
+) -> AsyncIterator[Tuple[
+    Union[T1, Any], Union[T2, Any], Union[T3, Any], Union[T4, Any], Union[T5, Any],
+]]: ...
+@overload
+def azip_longest(
+    __it1: AsyncIterable[T1], __it2: AsyncIterable[T2], __it3: AsyncIterable[T3],
+    __it4: AsyncIterable[T4], __it5: AsyncIterable[T5],
+    *, fillvalue: FillT,
+) -> AsyncIterator[Tuple[
+    Union[T1, FillT], Union[T2, FillT], Union[T3, FillT], Union[T4, FillT], Union[T5, FillT],
+]]: ...
 # Six or more
 @overload
 def azip_longest(

--- a/src/trio_util/_async_itertools.py
+++ b/src/trio_util/_async_itertools.py
@@ -1,13 +1,24 @@
+from typing import Any, AsyncIterable, AsyncIterator, Tuple, TypeVar, Union, overload
+
 import trio
 
 
-async def _azip(*aiterables, fillvalue, stop_any):
+T = TypeVar("T")
+T1 = TypeVar("T1")
+T2 = TypeVar("T2")
+T3 = TypeVar("T3")
+T4 = TypeVar("T4")
+T5 = TypeVar("T5")
+FillT = TypeVar("FillT")
+
+
+async def _azip(aiterables: Tuple[AsyncIterable[Any], ...], fillvalue: object, stop_any: bool) -> AsyncIterator[Tuple[Any, ...]]:
     iters = [item.__aiter__() for item in aiterables]
     while True:
         stop_count = 0
-        items = [fillvalue] * len(iters)
+        items: list[object] = [fillvalue] * len(iters)
 
-        async def collect(i, iterator):
+        async def collect(i: int, iterator: AsyncIterator[object]) -> None:
             try:
                 items[i] = await iterator.__anext__()
             except StopAsyncIteration:
@@ -23,11 +34,84 @@ async def _azip(*aiterables, fillvalue, stop_any):
         yield tuple(items)
 
 
-def azip(*aiterables):
+@overload
+def azip() -> AsyncIterator[Tuple[()]]: ...
+@overload
+def azip(__it1: AsyncIterable[T1]) -> AsyncIterator[Tuple[T1]]: ...
+@overload
+def azip(
+    __it1: AsyncIterable[T1], __it2: AsyncIterable[T2],
+) -> AsyncIterator[Tuple[T1, T2]]: ...
+@overload
+def azip(
+    __it1: AsyncIterable[T1], __it2: AsyncIterable[T2], __it3: AsyncIterable[T3],
+) -> AsyncIterator[Tuple[T1, T2, T3]]: ...
+@overload
+def azip(
+    __it1: AsyncIterable[T1], __it2: AsyncIterable[T2], __it3: AsyncIterable[T3],
+    __it4: AsyncIterable[T4]) -> AsyncIterator[Tuple[T1, T2, T3, T4]]: ...
+@overload
+def azip(
+    __it1: AsyncIterable[T1], __it2: AsyncIterable[T2], __it3: AsyncIterable[T3],
+    __it4: AsyncIterable[T4], __it5: AsyncIterable[T5],
+) -> AsyncIterator[Tuple[T1, T2, T3, T4, T5]]: ...
+@overload
+def azip(*aiterables: AsyncIterable[Any]) -> AsyncIterator[Tuple[Any, ...]]: ...
+def azip(*aiterables: AsyncIterable[Any]) -> AsyncIterator[Any]:
     """async version of zip() with parallel iteration"""
-    return _azip(*aiterables, fillvalue=None, stop_any=True)
+    return _azip(aiterables, fillvalue=None, stop_any=True)
 
 
-def azip_longest(*aiterables, fillvalue=None):
+# See typeshed's itertools.pyi for the reasoning behind these overloads.
+
+# One iterable, fillvalue is irrelevant.
+@overload
+def azip_longest(__it1: AsyncIterable[T1], *, fillvalue: object = ...) -> AsyncIterator[Tuple[T1]]: ...
+# Two iterables
+@overload
+def azip_longest(
+    __it1: AsyncIterable[T1], __it2: AsyncIterable[T2],
+) -> AsyncIterator[Tuple[Union[T1, Any], Union[T2, Any]]]: ...
+@overload
+def azip_longest(
+    __it1: AsyncIterable[T1], __it2: AsyncIterable[T2],
+    *, fillvalue: FillT,
+) -> AsyncIterator[Tuple[Union[T1, FillT], Union[T2, FillT]]]: ...
+# Three iterables
+@overload
+def azip_longest(
+    __it1: AsyncIterable[T1], __it2: AsyncIterable[T2], __it3: AsyncIterable[T3],
+) -> AsyncIterator[Tuple[Union[T1, Any], Union[T2, Any], Union[T3, Any]]]: ...
+@overload
+def azip_longest(
+    __it1: AsyncIterable[T1], __it2: AsyncIterable[T2], __it3: AsyncIterable[T3],
+    *, fillvalue: FillT,
+) -> AsyncIterator[Tuple[Union[T1, FillT], Union[T2, FillT], Union[T3, FillT]]]: ...
+# Four iterables
+@overload
+def azip_longest(
+    __it1: AsyncIterable[T1], __it2: AsyncIterable[T2], __it3: AsyncIterable[T3],
+    __it4: AsyncIterable[T4]) -> AsyncIterator[Tuple[T1, T2, T3, T4]]: ...
+# Five iterables
+@overload
+def azip_longest(
+    __it1: AsyncIterable[T1], __it2: AsyncIterable[T2], __it3: AsyncIterable[T3],
+    __it4: AsyncIterable[T4], __it5: AsyncIterable[T5],
+) -> AsyncIterator[Tuple[T1, T2, T3, T4, T5]]: ...
+# Six or more
+@overload
+def azip_longest(
+    __it1: AsyncIterable[T], __it2: AsyncIterable[T], __it3: AsyncIterable[T],
+    __it4: AsyncIterable[T], __it5: AsyncIterable[T],
+    *aiterables: AsyncIterable[T],
+) -> AsyncIterator[Tuple[Union[T, Any], ...]]: ...
+@overload
+def azip_longest(
+    __it1: AsyncIterable[T], __it2: AsyncIterable[T], __it3: AsyncIterable[T],
+    __it4: AsyncIterable[T], __it5: AsyncIterable[T],
+    *aiterables: AsyncIterable[T],
+    fillvalue: T,
+) -> AsyncIterator[Tuple[T, ...]]: ...
+def azip_longest(*aiterables: AsyncIterable[Any], fillvalue: object = None) -> AsyncIterator[Tuple[Any, ...]]:
     """async version of zip_longest() with parallel iteration"""
-    return _azip(*aiterables, fillvalue=fillvalue, stop_any=False)
+    return _azip(aiterables, fillvalue=fillvalue, stop_any=False)

--- a/src/trio_util/_async_value.py
+++ b/src/trio_util/_async_value.py
@@ -1,7 +1,7 @@
 # pylint: disable=line-too-long,multiple-statements
 from contextlib import contextmanager
 from typing import (
-    Any, Generator, TypeVar, Generic, AsyncIterator, Tuple,
+    Any, Generator, Set, TypeVar, Generic, AsyncIterator, Tuple,
     ContextManager, Callable, Union, overload,
 )
 
@@ -24,7 +24,7 @@ class _WaitQueue:
     __slots__ = ['tasks']
 
     def __init__(self) -> None:
-        self.tasks: set[trio.lowlevel.Task] = set()
+        self.tasks: Set[trio.lowlevel.Task] = set()
 
     async def park(self) -> None:
         task = lowlevel.current_task()

--- a/src/trio_util/_awaitables.py
+++ b/src/trio_util/_awaitables.py
@@ -1,13 +1,15 @@
+from typing import Awaitable, Callable
+
 import trio
 
 
-async def _wait_and_call(f1, f2):
+async def _wait_and_call(f1: Callable[[], Awaitable[object]], f2: Callable[[], object]) -> None:
     """await on f1() and call f2()"""
     await f1()
     f2()
 
 
-async def wait_any(*args):
+async def wait_any(*args: Callable[[], Awaitable[object]]) -> None:
     """Wait until any of the given async functions are completed.
 
     Equivalent to creating a new nursery and calling `start_soon()` on
@@ -25,7 +27,7 @@ async def wait_any(*args):
             nursery.start_soon(_wait_and_call, f, cancel)
 
 
-async def wait_all(*args):
+async def wait_all(*args: Callable[[], Awaitable[object]]) -> None:
     """Wait until all of the given async functions are completed.
 
     Equivalent to creating a new nursery and calling `start_soon()` on

--- a/src/trio_util/_cancel_scopes.py
+++ b/src/trio_util/_cancel_scopes.py
@@ -12,8 +12,10 @@ if TYPE_CHECKING:
 
 
 @asynccontextmanager
-async def move_on_when(fn: Callable['Args', Awaitable[object]],
-                       *args: 'Args.args', **kwargs: 'Args.kwargs') -> AsyncGenerator[trio.CancelScope, NoReturn]:
+async def move_on_when(
+    fn: 'Callable[Args, Awaitable[object]]',
+    *args: 'Args.args', **kwargs: 'Args.kwargs',
+) -> AsyncGenerator[trio.CancelScope, None]:
     """Async context manager that exits if async fn(*args, **kwargs) returns.
 
     The context manager yields a trio.CancelScope.
@@ -37,8 +39,10 @@ async def move_on_when(fn: Callable['Args', Awaitable[object]],
 
 
 @asynccontextmanager
-async def run_and_cancelling(fn: Callable['Args', Awaitable[object]],
-                       *args: 'Args.args', **kwargs: 'Args.kwargs') -> AsyncGenerator[None, NoReturn]:
+async def run_and_cancelling(
+    fn: 'Callable[Args, Awaitable[object]]',
+    *args: 'Args.args', **kwargs: 'Args.kwargs',
+) -> AsyncGenerator[None, None]:
     """Async context manager that runs async fn(*args, **kwargs) and cancels it at block exit.
 
     Synopsis::

--- a/src/trio_util/_cancel_scopes.py
+++ b/src/trio_util/_cancel_scopes.py
@@ -1,15 +1,19 @@
 from contextlib import asynccontextmanager
 from functools import partial
-from typing import Awaitable, Callable, AsyncIterator
+from typing import Awaitable, Callable, AsyncGenerator, NoReturn, TYPE_CHECKING
 
 import trio
 
 from ._awaitables import _wait_and_call
 
+if TYPE_CHECKING:
+    from typing_extensions import ParamSpec
+    Args = ParamSpec("Args")
+
 
 @asynccontextmanager
-async def move_on_when(fn: Callable[..., Awaitable],
-                       *args, **kwargs) -> AsyncIterator[trio.CancelScope]:
+async def move_on_when(fn: Callable['Args', Awaitable[object]],
+                       *args: 'Args.args', **kwargs: 'Args.kwargs') -> AsyncGenerator[trio.CancelScope, NoReturn]:
     """Async context manager that exits if async fn(*args, **kwargs) returns.
 
     The context manager yields a trio.CancelScope.
@@ -33,8 +37,8 @@ async def move_on_when(fn: Callable[..., Awaitable],
 
 
 @asynccontextmanager
-async def run_and_cancelling(fn: Callable[..., Awaitable],
-                             *args, **kwargs) -> AsyncIterator[None]:
+async def run_and_cancelling(fn: Callable['Args', Awaitable[object]],
+                       *args: 'Args.args', **kwargs: 'Args.kwargs') -> AsyncGenerator[None, NoReturn]:
     """Async context manager that runs async fn(*args, **kwargs) and cancels it at block exit.
 
     Synopsis::

--- a/src/trio_util/_cancel_scopes.py
+++ b/src/trio_util/_cancel_scopes.py
@@ -1,6 +1,6 @@
 from contextlib import asynccontextmanager
 from functools import partial
-from typing import Awaitable, Callable, AsyncGenerator, NoReturn, TYPE_CHECKING
+from typing import Awaitable, Callable, AsyncGenerator, TYPE_CHECKING
 
 import trio
 

--- a/src/trio_util/_compose_values.py
+++ b/src/trio_util/_compose_values.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 from contextlib import contextmanager, ExitStack
 from functools import partial
 from typing import (
-    ContextManager, Callable, Any, Dict, Iterator, NoReturn, Optional, TypeVar,
+    ContextManager, Callable, Any, Dict, Iterator, Optional, TypeVar,
     Union, overload,
 )
 

--- a/src/trio_util/_exceptions.py
+++ b/src/trio_util/_exceptions.py
@@ -12,7 +12,7 @@ import trio
 
 T = TypeVar('T')
 T_co = TypeVar('T_co', covariant=True)
-AsyncCallT = TypeVar('AsyncCallT', bound=Callable[..., Awaitable[object]])
+CallT = TypeVar('CallT', bound=Callable[..., object])
 
 if TYPE_CHECKING:
     from typing_extensions import ParamSpec, TypeAlias
@@ -25,7 +25,7 @@ else:
 
 class _ContextDecorator(Protocol[T_co]):
     """An object that can be used as both a context manager and decorator."""
-    def __call__(self, func: AsyncCallT) -> AsyncCallT:
+    def __call__(self, func: CallT) -> CallT:
         ...
 
     def __enter__(self) -> T_co:
@@ -42,7 +42,7 @@ class _AsyncFriendlyGeneratorContextManager(_GCM[T]):
     manager can properly decorate async functions.
     """
 
-    def __call__(self, func: AsyncCallT) -> AsyncCallT:
+    def __call__(self, func: CallT) -> CallT:
         # We can't type the internals properly - inside the true branch the return type is async,
         # but we can't express that. It needs to be a typevar bound to callable, so that it fully
         # preserves overloads and things like that.

--- a/src/trio_util/_iterators.py
+++ b/src/trio_util/_iterators.py
@@ -1,9 +1,12 @@
-from collections.abc import AsyncIterator
+from typing import AsyncIterator, Generic, TypeVar
 
 import trio
 
 
-class iter_move_on_after(AsyncIterator):
+T = TypeVar("T")
+
+
+class iter_move_on_after(AsyncIterator[T], Generic[T]):
     """async iterator adapter that stops if an iteration exceeds timeout
 
     The timeout is a duration in seconds.
@@ -16,18 +19,18 @@ class iter_move_on_after(AsyncIterator):
 
     __slots__ = ['_ait', '_timeout']
 
-    def __init__(self, timeout, ait):
+    def __init__(self, timeout: float, ait: AsyncIterator[T]) -> None:
         self._ait = ait
         self._timeout = timeout
 
-    async def __anext__(self):
+    async def __anext__(self) -> T:
         with trio.move_on_after(self._timeout):
             x = await self._ait.__anext__()
             return x
         raise StopAsyncIteration
 
 
-class iter_fail_after(AsyncIterator):
+class iter_fail_after(AsyncIterator[T], Generic[T]):
     """async iterator adapter that raises trio.TooSlowError if an iteration exceeds timeout
 
     The timeout is a duration in seconds.
@@ -40,10 +43,10 @@ class iter_fail_after(AsyncIterator):
 
     __slots__ = ['_ait', '_timeout']
 
-    def __init__(self, timeout, ait):
+    def __init__(self, timeout: float, ait: AsyncIterator[T]) -> None:
         self._ait = ait
         self._timeout = timeout
 
-    async def __anext__(self):
+    async def __anext__(self) -> T:
         with trio.fail_after(self._timeout):
             return await self._ait.__anext__()

--- a/src/trio_util/_iterators.py
+++ b/src/trio_util/_iterators.py
@@ -3,10 +3,10 @@ from typing import AsyncIterator, Generic, TypeVar
 import trio
 
 
-T = TypeVar("T")
+T_co = TypeVar("T_co", covariant=True)
 
 
-class iter_move_on_after(AsyncIterator[T], Generic[T]):
+class iter_move_on_after(AsyncIterator[T_co], Generic[T_co]):
     """async iterator adapter that stops if an iteration exceeds timeout
 
     The timeout is a duration in seconds.
@@ -19,18 +19,18 @@ class iter_move_on_after(AsyncIterator[T], Generic[T]):
 
     __slots__ = ['_ait', '_timeout']
 
-    def __init__(self, timeout: float, ait: AsyncIterator[T]) -> None:
+    def __init__(self, timeout: float, ait: AsyncIterator[T_co]) -> None:
         self._ait = ait
         self._timeout = timeout
 
-    async def __anext__(self) -> T:
+    async def __anext__(self) -> T_co:
         with trio.move_on_after(self._timeout):
             x = await self._ait.__anext__()
             return x
         raise StopAsyncIteration
 
 
-class iter_fail_after(AsyncIterator[T], Generic[T]):
+class iter_fail_after(AsyncIterator[T_co], Generic[T_co]):
     """async iterator adapter that raises trio.TooSlowError if an iteration exceeds timeout
 
     The timeout is a duration in seconds.
@@ -43,10 +43,10 @@ class iter_fail_after(AsyncIterator[T], Generic[T]):
 
     __slots__ = ['_ait', '_timeout']
 
-    def __init__(self, timeout: float, ait: AsyncIterator[T]) -> None:
+    def __init__(self, timeout: float, ait: AsyncIterator[T_co]) -> None:
         self._ait = ait
         self._timeout = timeout
 
-    async def __anext__(self) -> T:
+    async def __anext__(self) -> T_co:
         with trio.fail_after(self._timeout):
             return await self._ait.__anext__()

--- a/src/trio_util/_periodic.py
+++ b/src/trio_util/_periodic.py
@@ -1,6 +1,9 @@
+from typing import AsyncGenerator, Optional, Tuple
+
 import trio
 
-async def periodic(period):
+
+async def periodic(period: float) -> AsyncGenerator[Tuple[float, Optional[float]], None]:
     """Yield `(elapsed_time, delta_time)` with an interval of `period` seconds.
 
     For example, to loop indefinitely with a period of 1 second, accounting
@@ -13,9 +16,12 @@ async def periodic(period):
 
     On the first iteration, `delta_time` will be `None`.
     """
-    t0 = trio.current_time()
-    t_last, t_start = None, t0
+    t_start = t0 = trio.current_time()
+    t_last: Optional[float] = None
     while True:
-        yield t_start - t0, t_start - t_last if t_last is not None else None
+        if t_last is not None:
+            yield t_start - t0, t_start - t_last
+        else:
+            yield t_start - t0, None
         await trio.sleep_until(t_start + period)
         t_last, t_start = t_start, trio.current_time()

--- a/src/trio_util/_ref_counted_default_dict.py
+++ b/src/trio_util/_ref_counted_default_dict.py
@@ -1,4 +1,4 @@
-from typing import Callable, DefaultDict, Generator, Generic, TypeVar, overload
+from typing import Callable, DefaultDict, Generator, Generic, TypeVar
 from collections import defaultdict
 from contextlib import contextmanager
 

--- a/src/trio_util/_ref_counted_default_dict.py
+++ b/src/trio_util/_ref_counted_default_dict.py
@@ -1,16 +1,22 @@
+from typing import Callable, DefaultDict, Generator, Generic, TypeVar, overload
 from collections import defaultdict
 from contextlib import contextmanager
 
 
-class _RefCountedDefaultDict(defaultdict):
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+class _RefCountedDefaultDict(DefaultDict[K, V], Generic[K, V]):
     """defaultdict offering deterministic collection of unreferenced keys"""
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.refs_by_key = defaultdict(int)
+    # Add in other __init__ overloads if required.
+    def __init__(self, default_factory: Callable[[], V]) -> None:
+        super().__init__(default_factory)
+        self.refs_by_key: DefaultDict[K, int] = defaultdict(int)
 
     @contextmanager
-    def open_ref(self, key):
+    def open_ref(self, key: K) -> Generator[V, None, None]:
         """Context manager that holds a reference to key, yielding the corresponding value
 
         At context exit, the given key will be deleted if there are no other

--- a/src/trio_util/_repeated_event.py
+++ b/src/trio_util/_repeated_event.py
@@ -1,3 +1,5 @@
+from typing import AsyncIterator
+
 from ._async_value import AsyncValue
 
 
@@ -11,19 +13,19 @@ class RepeatedEvent:
           previous one, but receiving the latest event is ensured
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._event = AsyncValue(0)
 
-    def set(self):
+    def set(self) -> None:
         """Trigger an event"""
         self._event.value += 1
 
-    async def wait(self):
+    async def wait(self) -> None:
         """Wait for the next event"""
         token = self._event.value
         await self._event.wait_value(lambda val: val > token)
 
-    async def unqueued_events(self):
+    async def unqueued_events(self) -> AsyncIterator[None]:
         """Unqueued event iterator
 
         The listener will miss an event if it's blocked processing the previous
@@ -54,7 +56,7 @@ class RepeatedEvent:
         async for _ in self._event.transitions():
             yield
 
-    async def events(self, *, repeat_last=False):
+    async def events(self, *, repeat_last: bool = False) -> AsyncIterator[None]:
         """Event iterator with eventual consistency
 
         Use this iterator to coordinate some work whenever a collection

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -1,5 +1,5 @@
 mock  # for AsyncMock
-mypy >= 0.942
+mypy == 1.8.0  # Latest supporting Python 3.7
 pip-tools >= 5.5.0
 pylint
 pytest

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -32,9 +32,9 @@ mccabe==0.6.1
     # via pylint
 mock==4.0.3
     # via -r test-requirements.in
-mypy==0.942
+mypy==1.8.0
     # via -r test-requirements.in
-mypy-extensions==0.4.3
+mypy-extensions==1.0.0
     # via mypy
 outcome==1.1.0
     # via

--- a/test-requirements_trio-0.12.txt
+++ b/test-requirements_trio-0.12.txt
@@ -32,9 +32,9 @@ mccabe==0.6.1
     # via pylint
 mock==4.0.3
     # via -r test-requirements.in
-mypy==0.942
+mypy==1.8.0
     # via -r test-requirements.in
-mypy-extensions==0.4.3
+mypy-extensions==1.0.0
     # via mypy
 outcome==1.1.0
     # via

--- a/tests/test_async_bool.py
+++ b/tests/test_async_bool.py
@@ -1,7 +1,7 @@
 from trio_util import AsyncBool
 
 
-async def test_async_bool():
+async def test_async_bool() -> None:
     event = AsyncBool()
     assert event.value is False
     await event.wait_value(False)

--- a/tests/test_async_itertools.py
+++ b/tests/test_async_itertools.py
@@ -1,17 +1,21 @@
 from itertools import zip_longest
+from typing import AsyncIterator, Iterable, TypeVar
 
 import trio
 
 from trio_util import azip, azip_longest
 
 
-async def periodic_iter(it):
+T = TypeVar("T")
+
+
+async def periodic_iter(it: Iterable[T]) -> AsyncIterator[T]:
     for x in it:
         yield x
         await trio.sleep(1)
 
 
-async def test_azip(autojump_clock):
+async def test_azip(autojump_clock: trio.abc.Clock) -> None:
     t0 = trio.current_time()
     expected = zip(range(5), range(3), range(3))
     async for item in azip(
@@ -20,7 +24,7 @@ async def test_azip(autojump_clock):
     assert trio.current_time() - t0 == 3
 
 
-async def test_azip_longest(autojump_clock):
+async def test_azip_longest(autojump_clock: trio.abc.Clock) -> None:
     t0 = trio.current_time()
     expected = zip_longest(range(5), range(3), fillvalue=-10)
     async for item in azip_longest(

--- a/tests/test_awaitables.py
+++ b/tests/test_awaitables.py
@@ -5,10 +5,10 @@ import trio
 from trio_util import wait_all, wait_any
 
 
-async def test_all(nursery, autojump_clock):
+async def test_all(nursery: trio.Nursery, autojump_clock: trio.abc.Clock) -> None:
     count = 0
 
-    async def foo(duration):
+    async def foo(duration: int) -> None:
         await trio.sleep(duration)
         nonlocal count
         count += 1
@@ -17,10 +17,10 @@ async def test_all(nursery, autojump_clock):
     assert count == 2
 
 
-async def test_any(nursery, autojump_clock):
+async def test_any(nursery: trio.Nursery, autojump_clock: trio.abc.Clock) -> None:
     count = 0
 
-    async def foo(duration):
+    async def foo(duration: int) -> None:
         await trio.sleep(duration)
         nonlocal count
         count += 1

--- a/tests/test_cancel_scopes.py
+++ b/tests/test_cancel_scopes.py
@@ -5,7 +5,7 @@ from mock import AsyncMock  # type: ignore[attr-defined]
 from trio_util import move_on_when, run_and_cancelling
 
 
-async def test_move_on_when(autojump_clock):
+async def test_move_on_when(autojump_clock: trio.abc.Clock) -> None:
     event = trio.Event()
 
     async with move_on_when(event.wait) as cancel_scope:
@@ -26,7 +26,7 @@ async def test_move_on_when(autojump_clock):
     assert cancel_scope.cancelled_caught
 
 
-async def test_move_on_when_deadline(autojump_clock):
+async def test_move_on_when_deadline(autojump_clock: trio.abc.Clock) -> None:
     async with move_on_when(trio.sleep_forever) as cancel_scope:
         cancel_scope.deadline = trio.current_time() + 1
         await trio.sleep_forever()
@@ -35,7 +35,7 @@ async def test_move_on_when_deadline(autojump_clock):
     assert cancel_scope.cancelled_caught
 
 
-async def test_move_on_when_args():
+async def test_move_on_when_args() -> None:
     fn = AsyncMock()
 
     async with move_on_when(fn, 'foo', bar=10):
@@ -43,10 +43,10 @@ async def test_move_on_when_args():
     fn.assert_awaited_with('foo', bar=10)
 
 
-async def test_run_and_cancelling(autojump_clock):
+async def test_run_and_cancelling(autojump_clock: trio.abc.Clock) -> None:
     event = trio.Event()
 
-    async def _task():
+    async def _task() -> None:
         event.set()
         await trio.sleep_forever()
 
@@ -64,7 +64,7 @@ async def test_run_and_cancelling(autojump_clock):
     assert event2.is_set()
 
 
-async def test_run_and_cancelling_args():
+async def test_run_and_cancelling_args() -> None:
     fn = AsyncMock()
 
     async with run_and_cancelling(fn, 'foo', bar=10):

--- a/tests/test_compose_values.py
+++ b/tests/test_compose_values.py
@@ -1,4 +1,5 @@
 from functools import partial
+from typing import Any, Callable, Tuple
 
 import pytest
 import trio
@@ -6,13 +7,14 @@ from trio.testing import wait_all_tasks_blocked
 
 from trio_util import AsyncValue, compose_values
 
-async def test_compose_values(nursery):
+
+async def test_compose_values(nursery: trio.Nursery) -> None:
     async_x = AsyncValue(42)
     async_y = AsyncValue(0)
     done = trio.Event()
 
     @nursery.start_soon
-    async def _wait():
+    async def _wait() -> None:
         with compose_values(x=async_x, y=async_y) as composite:
             assert (composite.value.x, composite.value.y) == (42, 0)
             assert await composite.wait_value(lambda val: val.x < 0 < val.y) == (-1, 10)
@@ -34,19 +36,19 @@ async def test_compose_values(nursery):
     partial(compose_values, AsyncValue(0)),
     partial(compose_values, x=10),
 ])
-async def test_compose_values_wrong_usage(context):
+async def test_compose_values_wrong_usage(context: Callable[[], object]) -> None:
     with pytest.raises(TypeError):
-        with context():
+        with context():  # type: ignore
             pass
 
 
-async def test_compose_values_nested(nursery):
+async def test_compose_values_nested(nursery: trio.Nursery) -> None:
     async_x, async_y = AsyncValue(1), AsyncValue(2)
-    async_text = AsyncValue('foo')
+    async_text: AsyncValue[Any] = AsyncValue('foo')
     done = trio.Event()
 
     @nursery.start_soon
-    async def _wait():
+    async def _wait() -> None:
         with compose_values(x=async_x, y=async_y) as async_xy, \
                 compose_values(xy=async_xy, text=async_text) as composite:
             assert composite.value == ((1, 2), 'foo')
@@ -63,7 +65,7 @@ async def test_compose_values_nested(nursery):
     await done.wait()
 
 
-async def test_compose_values_transform():
+async def test_compose_values_transform() -> None:
     async_x = AsyncValue(42)
     async_y = AsyncValue(2)
 
@@ -74,7 +76,7 @@ async def test_compose_values_transform():
         assert composite.value == 420
 
 
-async def test_compose_values_fast_transition():
+async def test_compose_values_fast_transition() -> None:
     # Confirm that composed values are not subject to issues with missed
     # wakeups.  This is true because the implementation relays value changes
     # synchronously from the value setter.
@@ -82,7 +84,7 @@ async def test_compose_values_fast_transition():
     N = 5
 
     with compose_values(e=event) as composite:
-        async def _listener(expected):
+        async def _listener(expected: Any) -> None:
             await composite.wait_value(expected)
 
         async with trio.open_nursery() as nursery:

--- a/tests/test_iterators.py
+++ b/tests/test_iterators.py
@@ -1,37 +1,39 @@
+from typing import AsyncIterator
+
 import pytest
 import trio
 
 from trio_util import iter_move_on_after, iter_fail_after
 
 
-async def _generator(*durations):
+async def _generator(*durations: int) -> AsyncIterator[int]:
     for i, duration in enumerate(durations):
         await trio.sleep(duration)
         yield i
 
 
-async def test_iter_move_on_after(autojump_clock):
+async def test_iter_move_on_after(autojump_clock: trio.abc.Clock) -> None:
     last_i = None
     async for i in iter_move_on_after(20, _generator(0, 1, 1, 5, 1)):
         last_i = i
     assert last_i == 4
 
 
-async def test_iter_move_on_after_caught(autojump_clock):
+async def test_iter_move_on_after_caught(autojump_clock: trio.abc.Clock) -> None:
     last_i = None
     async for i in iter_move_on_after(2, _generator(0, 1, 1, 5, 1)):
         last_i = i
     assert last_i == 2
 
 
-async def test_iter_fail_after(autojump_clock):
+async def test_iter_fail_after(autojump_clock: trio.abc.Clock) -> None:
     last_i = None
     async for i in iter_fail_after(20, _generator(0, 1, 1, 5, 1)):
         last_i = i
     assert last_i == 4
 
 
-async def test_iter_fail_after_caught(autojump_clock):
+async def test_iter_fail_after_caught(autojump_clock: trio.abc.Clock) -> None:
     with pytest.raises(trio.TooSlowError):
         last_i = None
         try:

--- a/tests/test_periodic.py
+++ b/tests/test_periodic.py
@@ -2,7 +2,7 @@ import trio
 
 from trio_util import periodic
 
-async def test_periodic(autojump_clock):
+async def test_periodic(autojump_clock: trio.abc.Clock) -> None:
     count = 0
     t0 = trio.current_time()
     async for elapsed, dt in periodic(1.5):
@@ -15,7 +15,7 @@ async def test_periodic(autojump_clock):
     total_elapsed = trio.current_time() - t0
     assert total_elapsed == 4.5
 
-async def test_periodic_overrun(autojump_clock):
+async def test_periodic_overrun(autojump_clock: trio.abc.Clock) -> None:
     count = 0
     t0 = trio.current_time()
     async for elapsed, dt in periodic(1.5):

--- a/tests/test_repeated_event.py
+++ b/tests/test_repeated_event.py
@@ -5,7 +5,7 @@ from trio.testing import wait_all_tasks_blocked
 from trio_util import RepeatedEvent
 
 
-async def test_repeated_event_wait(nursery, autojump_clock):
+async def test_repeated_event_wait(nursery: trio.Nursery, autojump_clock: trio.abc.Clock) -> None:
     done = trio.Event()
     event = RepeatedEvent()
 
@@ -15,7 +15,7 @@ async def test_repeated_event_wait(nursery, autojump_clock):
             await event.wait()
 
     @nursery.start_soon
-    async def _listener():
+    async def _listener() -> None:
         await event.wait()
         done.set()
 
@@ -24,14 +24,14 @@ async def test_repeated_event_wait(nursery, autojump_clock):
     await done.wait()
 
 
-async def test_repeated_event_unqueued(nursery, autojump_clock):
+async def test_repeated_event_unqueued(nursery: trio.Nursery, autojump_clock: trio.abc.Clock) -> None:
     event = RepeatedEvent()
     counts = [0, 0]
 
     # a set() before the listener opens will not be queued
     event.set()
 
-    async def listener(i):
+    async def listener(i: int) -> None:
         async for _ in event.unqueued_events():
             counts[i] += 1
             await trio.sleep(i + 1)
@@ -58,14 +58,14 @@ async def test_repeated_event_unqueued(nursery, autojump_clock):
     assert counts == [2, 2]
 
 
-async def test_repeated_event_eventually_consistent(nursery, autojump_clock):
+async def test_repeated_event_eventually_consistent(nursery: trio.Nursery, autojump_clock: trio.abc.Clock) -> None:
     event = RepeatedEvent()
     counts = [0, 0]
 
     # a set() before the listener opens will not be queued
     event.set()
 
-    async def listener(i):
+    async def listener(i: int) -> None:
         async for _ in event.events():
             counts[i] += 1
             await trio.sleep(i + 1)
@@ -95,7 +95,7 @@ async def test_repeated_event_eventually_consistent(nursery, autojump_clock):
     assert counts == [3, 3]
 
 
-async def test_repeated_event_repeat_last(autojump_clock):
+async def test_repeated_event_repeat_last(autojump_clock: trio.abc.Clock) -> None:
     event = RepeatedEvent()
 
     # no event was set, repeat_last=True will still iterate immediately

--- a/tests/test_task_stats.py
+++ b/tests/test_task_stats.py
@@ -1,24 +1,28 @@
 import logging
 
-import trio
+import trio.testing
+import pytest
 
 from trio_util import TaskStats
 
 
-def test_task_stats(caplog, autojump_clock):
+def test_task_stats(
+    caplog: 'pytest.LogCaptureFixture',
+    autojump_clock: trio.testing.MockClock,
+) -> None:
     caplog.set_level(logging.INFO)
 
-    async def run():
+    async def run() -> None:
         async with trio.open_nursery() as nursery:
             @nursery.start_soon
-            async def _slow_step_task():
+            async def _slow_step_task() -> None:
                 for i in range(3):
                     # simulate a long step time
                     autojump_clock.jump((i + 1) * .1)
                     await trio.sleep(0)
 
             @nursery.start_soon
-            async def _high_reschedule_rate_task():
+            async def _high_reschedule_rate_task() -> None:
                 for _ in range(60):
                     await trio.sleep(1/60)
 

--- a/tests/test_trio_async_generator.py
+++ b/tests/test_trio_async_generator.py
@@ -1,4 +1,5 @@
 from math import inf
+from typing import AsyncGenerator
 
 import trio
 
@@ -8,7 +9,11 @@ from trio_util._trio_async_generator import trio_async_generator
 
 
 @trio_async_generator
-async def squares_in_range(start, stop, timeout=inf, max_timeout_count=1):
+async def squares_in_range(
+    start: int, stop: int,
+    timeout: float = inf,
+    max_timeout_count: int = 1,
+) -> AsyncGenerator[int, None]:
     timeout_count = 0
     for i in range(start, stop):
         with trio.move_on_after(timeout) as cancel_scope:
@@ -20,7 +25,7 @@ async def squares_in_range(start, stop, timeout=inf, max_timeout_count=1):
                 break
 
 
-async def test_trio_agen_full_iteration():
+async def test_trio_agen_full_iteration() -> None:
     last = None
     async with squares_in_range(0, 50) as squares:
         async for square in squares:
@@ -28,7 +33,7 @@ async def test_trio_agen_full_iteration():
     assert last == 49 ** 2
 
 
-async def test_trio_agen_caller_exits():
+async def test_trio_agen_caller_exits() -> None:
     async with squares_in_range(0, 50) as squares:
         async for square in squares:
             if square >= 400:
@@ -36,7 +41,7 @@ async def test_trio_agen_caller_exits():
     assert False
 
 
-async def test_trio_agen_caller_cancelled(autojump_clock):
+async def test_trio_agen_caller_cancelled(autojump_clock: trio.abc.Clock) -> None:
     with trio.move_on_after(1):
         async with squares_in_range(0, 50) as squares:
             async for square in squares:
@@ -45,7 +50,7 @@ async def test_trio_agen_caller_cancelled(autojump_clock):
                 await trio.sleep(10)
 
 
-async def test_trio_agen_aborts_yield(autojump_clock):
+async def test_trio_agen_aborts_yield(autojump_clock: trio.abc.Clock) -> None:
     async with squares_in_range(0, 50, timeout=.5, max_timeout_count=1) as squares:
         async for square in squares:
             assert square == 0
@@ -53,7 +58,7 @@ async def test_trio_agen_aborts_yield(autojump_clock):
             await trio.sleep(1)
 
 
-async def test_trio_agen_aborts_yield_and_continues(autojump_clock):
+async def test_trio_agen_aborts_yield_and_continues(autojump_clock: trio.abc.Clock) -> None:
     async with squares_in_range(0, 50, timeout=.5, max_timeout_count=99) as squares:
         _sum = 0
         async for square in squares:


### PR DESCRIPTION
This adds type hints to all definitions in the package, as well as the tests.  It passes mypy's strict mode, with some caveats:

* `_exceptions` will break if you use newer `trio` versions due to the removal of `MultiError`. 
* `compose_values()` is untypable due to it creating new named tuples with every call. Therefore the attribute names aren't checked, but they produce the right value, and it is a tuple subclass.
* Like the sync versions, `azip()`/`azip_longest()` just accurately types up to 5 arguments.
* I bumped mypy to the latest version which supports Python 3.7 (0.8.0).
