### PR TITLE
remove 3rd party mock package dependency

### DIFF
--- a/test-requirements.in
+++ b/test-requirements.in
@@ -1,8 +1,6 @@
-mock  # for AsyncMock
 mypy >= 0.942
 pip-tools >= 5.5.0
 pylint
 pytest
 pytest-cov
 pytest-trio
-types-mock

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -35,8 +35,6 @@ isort==5.8.0
     # via pylint
 mccabe==0.6.1
     # via pylint
-mock==4.0.3
-    # via -r test-requirements.in
 mypy==0.942
     # via -r test-requirements.in
 mypy-extensions==0.4.3
@@ -90,8 +88,6 @@ trio==0.18.0
     # via
     #   pytest-trio
     #   trio_util (setup.py)
-types-mock==4.0.1
-    # via -r test-requirements.in
 typing-extensions==4.1.1
     # via
     #   astroid

--- a/test-requirements_trio-0.12.txt
+++ b/test-requirements_trio-0.12.txt
@@ -34,8 +34,6 @@ lazy-object-proxy==1.6.0
     # via astroid
 mccabe==0.6.1
     # via pylint
-mock==4.0.3
-    # via -r test-requirements.in
 mypy==0.942
     # via -r test-requirements.in
 mypy-extensions==0.4.3
@@ -84,8 +82,6 @@ trio==0.12.0
     # via
     #   pytest-trio
     #   trio-util (setup.py)
-types-mock==4.0.1
-    # via -r test-requirements.in
 typing-extensions==4.1.1
     # via
     #   astroid

--- a/tests/test_cancel_scopes.py
+++ b/tests/test_cancel_scopes.py
@@ -1,6 +1,6 @@
-import trio
+from unittest.mock import AsyncMock
 
-from mock import AsyncMock  # type: ignore[attr-defined]
+import trio
 
 from trio_util import move_on_when, run_and_cancelling
 


### PR DESCRIPTION
AsyncMock exists in standard library since Python 3.8