### PR TITLE
fix tests/lint/type_check for recent Trio versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,26 @@
 .PHONY: all
 all: test lint type_check
 
+# ignore exceptions utilities when MultiError is not available or deprecated
+ifneq ($(shell python -c 'from trio import MultiError' 2>&1), )
+IGNORE_FILES_REGEX=".*_exceptions.py"
+IGNORE_FILES_GLOB="*_exceptions.py"
+else
+IGNORE_FILES_REGEX="^$$"
+IGNORE_FILES_GLOB=""
+endif
+
 .PHONY: test
 test:
-	PYTHONPATH=src python -m pytest --cov=src/ --no-cov-on-fail $(PYTEST_ARGS) tests/
+	PYTHONPATH=src python -m pytest --cov=src/ --no-cov-on-fail $(PYTEST_ARGS) --ignore-glob $(IGNORE_FILES_GLOB) tests/
 
 .PHONY: lint
 lint:
-	PYTHONPATH=src python -m pylint src/ tests/
+	PYTHONPATH=src python -m pylint --ignore-patterns $(IGNORE_FILES_REGEX) src/ tests/
 
 .PHONY: type_check
 type_check:
-	PYTHONPATH=src mypy --show-error-codes --check-untyped-defs --ignore-missing-imports src/ tests/
+	PYTHONPATH=src mypy --show-error-codes --check-untyped-defs --ignore-missing-imports --exclude $(IGNORE_FILES_REGEX) src/ tests/
 
 # explicitly update .txt after changing .in:
 #   make -W test-requirements.{in,txt} PIP_COMPILE_ARGS="-q"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -180,6 +180,9 @@ and :func:`itertools.zip_longest`.
 
 exceptions
 ----------
+(These are only supported for older versions of Trio that used ``MultiError``
+rather than ``ExceptionGroup``.)
+
 .. autofunction:: multi_error_defer_to
     :no-auto-options:
     :with:

--- a/src/trio_util/_periodic.py
+++ b/src/trio_util/_periodic.py
@@ -18,7 +18,7 @@ async def periodic(period) -> AsyncGenerator[Tuple[float, Optional[float]], None
     """
     t0 = trio.current_time()
     t_start = t0
-    delta_time = None
+    delta_time: Optional[float] = None
     while True:
         yield t_start - t0, delta_time
         await trio.sleep_until(t_start + period)

--- a/src/trio_util/_periodic.py
+++ b/src/trio_util/_periodic.py
@@ -1,6 +1,9 @@
+from typing import AsyncGenerator, Tuple, Optional
+
 import trio
 
-async def periodic(period):
+
+async def periodic(period) -> AsyncGenerator[Tuple[float, Optional[float]], None]:
     """Yield `(elapsed_time, delta_time)` with an interval of `period` seconds.
 
     For example, to loop indefinitely with a period of 1 second, accounting
@@ -14,8 +17,10 @@ async def periodic(period):
     On the first iteration, `delta_time` will be `None`.
     """
     t0 = trio.current_time()
-    t_last, t_start = None, t0
+    t_start = t0
+    delta_time = None
     while True:
-        yield t_start - t0, t_start - t_last if t_last is not None else None
+        yield t_start - t0, delta_time
         await trio.sleep_until(t_start + period)
         t_last, t_start = t_start, trio.current_time()
+        delta_time = t_start - t_last

--- a/src/trio_util/_trio_async_generator.py
+++ b/src/trio_util/_trio_async_generator.py
@@ -39,7 +39,7 @@ def trio_async_generator(wrapped):
     @asynccontextmanager
     @functools.wraps(wrapped)
     async def wrapper(*args, **kwargs):
-        send_channel, receive_channel = trio.open_memory_channel(0)
+        send_channel, receive_channel = trio.open_memory_channel(0)  # type: ignore[var-annotated]
         async with trio.open_nursery() as nursery:
             async def adapter():
                 async with send_channel, aclosing(wrapped(*args, **kwargs)) as agen:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,95 +4,93 @@
 #
 #    pip-compile --output-file=test-requirements.txt setup.py test-requirements.in
 #
-astroid==3.1.0
+astroid==3.2.4
     # via pylint
 async-generator==1.10
     # via trio_util (setup.py)
-attrs==20.3.0
+attrs==24.2.0
     # via
     #   outcome
     #   trio
-build==1.2.1
+build==1.2.2.post1
     # via pip-tools
-click==8.0.1
+click==8.1.7
     # via pip-tools
-coverage==5.5
+coverage[toml]==7.6.1
     # via pytest-cov
-dill==0.3.8
+dill==0.3.9
     # via pylint
 exceptiongroup==1.2.2
     # via
     #   pytest
     #   trio
-idna==3.1
+idna==3.10
     # via trio
 importlib-metadata==8.5.0
     # via build
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via pytest
-isort==5.8.0
+isort==5.13.2
     # via pylint
-mccabe==0.6.1
+mccabe==0.7.0
     # via pylint
-mypy==1.0.1
+mypy==1.13.0
     # via -r test-requirements.in
-mypy-extensions==0.4.3
+mypy-extensions==1.0.0
     # via mypy
-outcome==1.1.0
+outcome==1.3.0.post0
     # via
     #   pytest-trio
     #   trio
-packaging==20.9
+packaging==24.2
     # via
     #   build
     #   pytest
 pip-tools==7.4.1
     # via -r test-requirements.in
-platformdirs==4.2.0
+platformdirs==4.3.6
     # via pylint
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
-pylint==3.1.1
+pylint==3.2.7
     # via -r test-requirements.in
-pyparsing==2.4.7
-    # via packaging
-pyproject-hooks==1.0.0
+pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-pytest==8.1.2
+pytest==8.3.3
     # via
     #   -r test-requirements.in
     #   pytest-cov
     #   pytest-trio
-pytest-cov==2.11.1
+pytest-cov==5.0.0
     # via -r test-requirements.in
 pytest-trio==0.8.0
     # via -r test-requirements.in
-sniffio==1.2.0
+sniffio==1.3.1
     # via trio
-sortedcontainers==2.3.0
+sortedcontainers==2.4.0
     # via trio
 tomli==2.1.0
     # via
     #   build
+    #   coverage
     #   mypy
     #   pip-tools
     #   pylint
-    #   pyproject-hooks
     #   pytest
-tomlkit==0.12.4
+tomlkit==0.13.2
     # via pylint
-trio==0.22.2
+trio==0.27.0
     # via
     #   pytest-trio
     #   trio_util (setup.py)
-typing-extensions==4.1.1
+typing-extensions==4.12.2
     # via
     #   astroid
     #   mypy
     #   pylint
-wheel==0.36.2
+wheel==0.45.0
     # via pip-tools
 zipp==3.20.2
     # via importlib-metadata

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,10 +7,7 @@
 astroid==3.1.0
     # via pylint
 async-generator==1.10
-    # via
-    #   pytest-trio
-    #   trio
-    #   trio_util (setup.py)
+    # via trio_util (setup.py)
 attrs==20.3.0
     # via
     #   outcome
@@ -23,11 +20,13 @@ coverage==5.5
     # via pytest-cov
 dill==0.3.8
     # via pylint
-exceptiongroup==1.2.0
-    # via pytest
+exceptiongroup==1.2.2
+    # via
+    #   pytest
+    #   trio
 idna==3.1
     # via trio
-importlib-metadata==7.1.0
+importlib-metadata==8.5.0
     # via build
 iniconfig==1.1.1
     # via pytest
@@ -35,7 +34,7 @@ isort==5.8.0
     # via pylint
 mccabe==0.6.1
     # via pylint
-mypy==0.942
+mypy==1.0.1
     # via -r test-requirements.in
 mypy-extensions==0.4.3
     # via mypy
@@ -53,7 +52,7 @@ platformdirs==4.2.0
     # via pylint
 pluggy==1.4.0
     # via pytest
-pylint==3.1.0
+pylint==3.1.1
     # via -r test-requirements.in
 pyparsing==2.4.7
     # via packaging
@@ -61,20 +60,20 @@ pyproject-hooks==1.0.0
     # via
     #   build
     #   pip-tools
-pytest==8.1.1
+pytest==8.1.2
     # via
     #   -r test-requirements.in
     #   pytest-cov
     #   pytest-trio
 pytest-cov==2.11.1
     # via -r test-requirements.in
-pytest-trio==0.7.0
+pytest-trio==0.8.0
     # via -r test-requirements.in
 sniffio==1.2.0
     # via trio
 sortedcontainers==2.3.0
     # via trio
-tomli==2.0.1
+tomli==2.1.0
     # via
     #   build
     #   mypy
@@ -84,7 +83,7 @@ tomli==2.0.1
     #   pytest
 tomlkit==0.12.4
     # via pylint
-trio==0.18.0
+trio==0.22.2
     # via
     #   pytest-trio
     #   trio_util (setup.py)
@@ -95,7 +94,7 @@ typing-extensions==4.1.1
     #   pylint
 wheel==0.36.2
     # via pip-tools
-zipp==3.18.1
+zipp==3.20.2
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
Runtime isn't changed.  Just exclude exception utilities from the static build checks.  (The exception utilities have a runtime dependency on the defunct trio.MultiError, but if you don't use them, it's fine.)

also:
  * upgrade test dependencies
  * add typing to periodic()
